### PR TITLE
fix: optimisations in middleware functions

### DIFF
--- a/src/views/map/layer/Stage.tsx
+++ b/src/views/map/layer/Stage.tsx
@@ -1,6 +1,5 @@
 import { Stage, useApp } from "@pixi/react";
 import { ReactNode, useEffect } from "react";
-import { useShallow } from "zustand/react/shallow";
 import { Application } from "pixi.js";
 import { useMapViewStore } from "../../../store/mapview";
 
@@ -32,7 +31,7 @@ type PIXIStageProps = React.ComponentProps<typeof Stage> & {
 }
 
 function PIXIStage({ width, height, children, ...props }: PIXIStageProps) {
-    const stageResizeNoTrack = useMapViewStore(useShallow(state => state.setStage))
+    const stageResizeNoTrack = useMapViewStore(state => state.setStage)
     useEffect(() => {
         stageResizeNoTrack(width, height)
     }, [width, height, stageResizeNoTrack])


### PR DESCRIPTION
### Optimizations & Refactors.

#### Changes Made:

path: src\views\map\mode\ptedit\index.tsx
-  Refactored:  useState was used for the stateMachine class, but now useRef is used as it is more appropriate.
-  Added: useMemo for optimizing the tabs.
-  Updated: Moved onContextMenu from PtEditStage (❌) to PtEditView (✅).
-  Added: Memoized the custom context component for better performance.
-  Added: Added (active === index && "btn-active") class which was missing.

path: src\store\osmmeta\middleware\computed\index.ts
-  Optimized: genTree - remove unnecessary computations and extra re-renders.
-  Optimized: genCollection.

path: src\views\map\layer\Stage.tsx
-  Removed: useShallow as it was no longer needed.